### PR TITLE
chore(generateWallet): rename avax -> avaxc

### DIFF
--- a/src/generateWallet/generateWallet.ts
+++ b/src/generateWallet/generateWallet.ts
@@ -29,7 +29,7 @@ export enum CoinType {
   DOT = 354,
   ERD = 508,
   NEO = 888,
-  AVAX = 9000
+  AVAXC = 9000
 }
 
 const NON_SEGWIT = [CoinType.BCH, CoinType.DOGE]
@@ -93,7 +93,7 @@ export function deriveIndex(extendedKey: bip32.BIP32Interface, index: number): b
 
 export const coinTypeFromString = (s: string): CoinType => {
   const m: Record<string, CoinType> = {
-    avax: CoinType.AVAX,
+    avaxc: CoinType.AVAXC,
     bch: CoinType.BCH,
     btc: CoinType.BTC,
     doge: CoinType.DOGE,
@@ -179,7 +179,7 @@ function generateWalletForCoinType(key: bip32.BIP32Interface, coinType: CoinType
       }
     case CoinType.ETH:
     case CoinType.ETC:
-    case CoinType.AVAX:
+    case CoinType.AVAXC:
       // TODO: can we replace this with the elliptic package which we already
       // use to trim bundle size?
       const pubkey = tiny.pointFromScalar(key.privateKey, false)


### PR DESCRIPTION
Renames it to the same name as the backend uses.