### PR TITLE
Fix: @neon-exchange/nash-protocol setup issues in Next.js v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "license": "MIT",
   "keywords": [],
   "scripts": {
-    "copy:native": "cp src/native/index_osx.node build/main/native && cp src/native/index_osx_arm64.node build/main/native && cp src/native/index_arm.node build/main/native && cp src/native/index_linux.node build/main/native && cp src/native/index_win.node build/main/native",
-    "build": "yarn clean && yarn build:main && yarn build:module && yarn copy:native",
+    "copy:native-to-main": "cp src/native/index_osx.node build/main/native && cp src/native/index_osx_arm64.node build/main/native && cp src/native/index_arm.node build/main/native && cp src/native/index_linux.node build/main/native && cp src/native/index_win.node build/main/native",
+    "copy:native-to-module": "cp src/native/index_osx.node build/module/native && cp src/native/index_osx_arm64.node build/module/native && cp src/native/index_arm.node build/module/native && cp src/native/index_linux.node build/module/native && cp src/native/index_win.node build/module/native",
+    "build": "yarn clean && yarn build:main && yarn copy:native-to-main && yarn build:module && yarn copy:native-to-module",
     "build:main": "tsc -p tsconfig.json",
     "build:module": "tsc -p tsconfig.module.json",
     "fix": "yarn fix:prettier && yarn fix:tslint",
@@ -86,5 +87,6 @@
     "exclude": [
       "**/*.spec.js"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,5 @@
     "exclude": [
       "**/*.spec.js"
     ]
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export { fillRPool, configurePoolSettings, getDhPoolSize } from './mpc/fillRPool
 export { fillRPoolIfNeeded } from './mpc/fillRPool'
 export { generateAPIKeys } from './mpc/generateAPIKeys'
 export { createAPIKey } from './mpc/createAPIKey'
-export { forceWasm } from './mpc-lib'
+export { forceWasm } from './native/forceWasm'
 export { publicKeyFromSecretKey } from './mpc/publicKeyFromSecretKey'
 export { default as regenerateMnemonic } from './regenerateMnemonic'
 export { default as secretKeyToMnemonic } from './secretKeyToMnemonic'

--- a/src/native/forceWasm.ts
+++ b/src/native/forceWasm.ts
@@ -1,0 +1,10 @@
+
+let usingWasm = false
+
+export function getUsingWasm(): boolean {
+  return usingWasm
+}
+
+export function forceWasm(): void {
+  usingWasm = true
+}

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -13,12 +13,8 @@ import {
   sign as wasm_sign,
   publickey_from_secretkey as wasm_publickey_from_secretkey
 } from 'mpc-wallet-wasm'
+import { getUsingWasm, forceWasm } from './forceWasm'
 
-let usingWasm = false
-
-export function forceWasm(): void {
-  usingWasm = true
-}
 
 interface NodeFileInterface {
   dh_init: (size: number, curve: string) => string
@@ -30,7 +26,7 @@ interface NodeFileInterface {
 }
 
 const loadNodeFile = (): NodeFileInterface | null => {
-  if (usingWasm) {
+  if (getUsingWasm()) {
     return null
   }
 
@@ -58,33 +54,33 @@ const loadNodeFile = (): NodeFileInterface | null => {
       return require(/* webpackIgnore: true */ './index_osx.node')
     default:
       console.log('Using .wasm shim')
-      usingWasm = true
+      forceWasm()
       return null
   }
 }
 
 const MpcWallet = loadNodeFile() as NodeFileInterface
 export function dh_init(size: number, curve: string): string {
-  if (usingWasm) {
+  if (getUsingWasm()) {
     return wasm_dh_init(size, curve)
   }
   return MpcWallet.dh_init(size, curve)
 }
 
 export function fill_rpool(clientDHSecrets: string, serverDHPublics: string, curve: string, pkstr: string): string {
-  if (usingWasm) {
+  if (getUsingWasm()) {
     return wasm_fill_rpool(clientDHSecrets, serverDHPublics, curve, pkstr)
   }
   return MpcWallet.fill_rpool(clientDHSecrets, serverDHPublics, pkstr, curve)
 }
 export function get_rpool_size(curve: string): string {
-  if (usingWasm) {
+  if (getUsingWasm()) {
     return wasm_get_rpool_size(curve)
   }
   return MpcWallet.get_rpool_size(curve)
 }
 export function compute_presig(apiKeyStr: string, msgHashStr: string, curve: string): string {
-  if (usingWasm) {
+  if (getUsingWasm()) {
     return wasm_compute_presig(apiKeyStr, msgHashStr, curve)
   }
   return MpcWallet.compute_presig(apiKeyStr, msgHashStr, curve)


### PR DESCRIPTION
The PR fixes these issues:

1)  Native libs copy issue
- We should copy them not only to `./build/main`, but also to `./build/module`

2) `mpc-wallet-wasm` load on any `@neon-exchange/nash-protocol` import
- It happens because of the `forceWasm` re-export in the `src/index.ts`, which triggers load of the `mpc-wallet-wasm` library, but we don't need to load wasm for every function, so it's better to load it separately via `import(...)`
- i've moved `forceWasm` function to another file, so it doesn't import `mpc-wallet-wasm` library